### PR TITLE
feat: add Go 1.25+ WaitGroup.Go examples to concurrency docs

### DIFF
--- a/concurrency/wait-groups.md
+++ b/concurrency/wait-groups.md
@@ -39,6 +39,38 @@ func main() {
 }
 ```
 
+### Go 1.25+ Usage with WaitGroup.Go
+
+Starting with Go 1.25, the new `Go` method added to `sync.WaitGroup` allows you to launch goroutines and manage the counter automatically:
+
+```go
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func worker(id int) {
+	fmt.Printf("Processing task %d\n", id)
+	// Simulate work.
+	fmt.Printf("Task %d completed\n", id)
+}
+
+func main() {
+	var wg sync.WaitGroup
+
+       for i := 0; i < 3; i++ {
+	       wg.Go(func() { worker(i) })
+       }
+
+	wg.Wait()
+	fmt.Println("All tasks completed")
+}
+```
+
+In this usage, the `worker` function no longer needs a `*sync.WaitGroup` parameter. The counter is managed automatically.
+
 In this example, a simple worker function is executed concurrently. The `sync.WaitGroup` is used to ensure that the `main` function waits for all worker goroutines to complete before exit.
 
 ## Practical Usage with Error Handling
@@ -76,9 +108,9 @@ func main() {
 		go worker(i, &wg, errChan)
 	}
 
-	
+
 	wg.Wait()
-	close(errChan)	
+	close(errChan)
 
 	for err := range errChan {
 		if err != nil {
@@ -88,6 +120,51 @@ func main() {
 	fmt.Println("All tasks completed")
 }
 ```
+
+### Go 1.25+ Usage with WaitGroup.Go and Error Handling
+
+With Go 1.25, the same example can be written more concisely as follows:
+
+```go
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+const numWorkers = 5
+
+func worker(id int, errChan chan<- error) {
+	// Simulate a task.
+	if id%2 == 0 {
+		errChan <- fmt.Errorf("task %d encountered an error", id)
+		return
+	}
+	fmt.Printf("Task %d completed successfully\n", id)
+}
+
+func main() {
+	var wg sync.WaitGroup
+	errChan := make(chan error, numWorkers)
+
+       for i := 0; i < numWorkers; i++ {
+	       wg.Go(func() { worker(i, errChan) })
+       }
+
+	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		if err != nil {
+			fmt.Println("Error:", err)
+		}
+	}
+	fmt.Println("All tasks completed")
+}
+```
+
+In this example, the counter is also managed automatically, so there is no need to call `wg.Done()` or `wg.Add()`.
 
 ## Best Practices
 

--- a/concurrency/worker-pools.md
+++ b/concurrency/worker-pools.md
@@ -90,9 +90,9 @@ func main() {
 	var wg sync.WaitGroup
 
 	// Start workers.
-       for w := 0; w < numWorkers; w++ {
-	       wg.Go(func() { worker(w, jobs, results) })
-       }
+	for w := 0; w < numWorkers; w++ {
+		wg.Go(func() { worker(w, jobs, results) })
+	}
 
 	// Send jobs to the workers.
 	for j := 0; j < numJobs; j++ {


### PR DESCRIPTION
# Add Go 1.25+ WaitGroup.Go Examples

Updates concurrency documentation with Go 1.25's new `WaitGroup.Go` method examples.

## Changes
- Added `WaitGroup.Go` examples to `wait-groups.md` and `worker-pools.md`
- Automatic counter management (no manual `Add()`/`Done()`)
- Cleaner worker function signatures
- Preserved existing examples for backward compatibility
